### PR TITLE
Troyabbs #37 create single event page

### DIFF
--- a/src/app/(frontend)/events/[slug]/_components/EventPage.tsx
+++ b/src/app/(frontend)/events/[slug]/_components/EventPage.tsx
@@ -1,0 +1,43 @@
+import Image from 'next/image'
+import { RichText } from '@payloadcms/richtext-lexical/react'
+
+import type { Event } from '@/payload-types'
+
+interface EventPageProps {
+  event: Event
+}
+
+export function EventPage({ event }: EventPageProps) {
+  return (
+    <div className="p-4">
+      <h1 className="text-center text-2xl font-bold">{event.title}</h1>
+      <div className="mt-4 block border p-2">
+        <div className="h-144 p-2">
+          {event.featuredImage &&
+            typeof event.featuredImage !== 'number' &&
+            event.featuredImage.url && (
+              <Image
+                src={event.featuredImage.url}
+                alt={event.title || ''}
+                className="h-full w-full object-cover"
+                width={300}
+                height={200}
+              />
+            )}
+        </div>
+        <div className="p-2">
+          {event.description && <RichText data={event.description} />}
+          <div className="mt-4 text-center">
+            {event.startTime && (
+              <p>Start: {new Date(event.startTime).toLocaleString()}</p>
+            )}
+            {event.endTime && (
+              <p>End: {new Date(event.endTime).toLocaleString()}</p>
+            )}
+            {event.location && <p>Location: {event.location}</p>}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/events/[slug]/_components/EventPageFallback.tsx
+++ b/src/app/(frontend)/events/[slug]/_components/EventPageFallback.tsx
@@ -1,0 +1,16 @@
+export function EventPageFallback() {
+  return (
+    <div className="p-4">
+      <div className="mx-auto h-6 w-1/2 animate-pulse rounded bg-gray-300" />
+      <div className="mt-4 block border p-2">
+        <div className="m-2 h-144 animate-pulse rounded bg-gray-200 p-2" />
+        <div className="space-y-4 p-2">
+          <div className="mx-auto h-30 w-full animate-pulse rounded bg-gray-200" />
+          <div className="mx-auto h-4 w-1/4 animate-pulse rounded bg-gray-200" />
+          <div className="mx-auto h-4 w-1/4 animate-pulse rounded bg-gray-200" />
+          <div className="mx-auto h-4 w-1/4 animate-pulse rounded bg-gray-200" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/events/[slug]/error.tsx
+++ b/src/app/(frontend)/events/[slug]/error.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
+  return (
+    <div>
+      <p>Error:</p>
+      <p>{error.message}</p>
+      <button onClick={reset}>Try again</button>
+    </div>
+  )
+}

--- a/src/app/(frontend)/events/[slug]/loading.tsx
+++ b/src/app/(frontend)/events/[slug]/loading.tsx
@@ -1,0 +1,9 @@
+import { EventPageFallback } from './_components/EventPageFallback'
+
+export default function Loading() {
+  return (
+    <div>
+      <EventPageFallback />
+    </div>
+  )
+}

--- a/src/app/(frontend)/events/[slug]/not-found.tsx
+++ b/src/app/(frontend)/events/[slug]/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div>
+      <div>Event not found.</div>
+      <Link href="/events">Return to Events</Link>
+    </div>
+  )
+}

--- a/src/app/(frontend)/events/[slug]/page.tsx
+++ b/src/app/(frontend)/events/[slug]/page.tsx
@@ -1,23 +1,20 @@
 import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
 
 import { getEventBySlug } from '@/queries/events'
 import { EventPage } from './_components/EventPage'
 import { EventPageFallback } from './_components/EventPageFallback'
-
-const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
 export default async function SpecificEventPage({
   params,
 }: {
   params: Promise<{ slug: string }>
 }) {
-  await delay(2000)
   const { slug } = await params
-
   const event = await getEventBySlug(slug)
 
   if (!event || event.status !== 'published') {
-    return <div>Event not found</div>
+    notFound()
   }
 
   return (

--- a/src/app/(frontend)/events/[slug]/page.tsx
+++ b/src/app/(frontend)/events/[slug]/page.tsx
@@ -1,18 +1,31 @@
+import { Suspense } from 'react'
+
+import { getEventBySlug } from '@/queries/events'
+import { EventPage } from './_components/EventPage'
+import { EventPageFallback } from './_components/EventPageFallback'
+
+const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
+
 export default async function SpecificEventPage({
   params,
 }: {
   params: Promise<{ slug: string }>
 }) {
+  await delay(2000)
   const { slug } = await params
+
+  const event = await getEventBySlug(slug)
+
+  if (!event || event.status !== 'published') {
+    return <div>Event not found</div>
+  }
 
   return (
     <div>
       <div>
-        <h1>Welcome to the specific event page, current event is {slug}</h1>
-        <p>Update this page by editing</p>
-        <a>
-          <code>app/(frontend)/events/[slugs]/page.tsx</code>
-        </a>
+        <Suspense fallback={<EventPageFallback />}>
+          <EventPage event={event} />
+        </Suspense>
       </div>
     </div>
   )

--- a/src/collections/events.ts
+++ b/src/collections/events.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import slugify from 'slugify'
 
 import { anyone } from '@/access/anyone'
 import { authenticated } from '@/access/authenticated'
@@ -10,6 +11,19 @@ export const Events: CollectionConfig = {
     read: anyone,
     update: authenticated,
     delete: authenticated,
+  },
+  hooks: {
+    beforeChange: [
+      ({ data, originalDoc }) => {
+        if (data.title && data.title !== originalDoc?.title) {
+          data.slug = slugify(data.title, {
+            lower: true,
+            strict: true,
+          })
+        }
+        return data
+      },
+    ],
   },
   fields: [
     {
@@ -68,6 +82,18 @@ export const Events: CollectionConfig = {
       name: 'featuredImage',
       type: 'upload',
       relationTo: 'media',
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      unique: true,
+      index: true,
+      label: 'Slug',
+      admin: {
+        readOnly: true,
+        description: 'Automatically generated from name',
+        hidden: true,
+      },
     },
   ],
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -237,6 +237,10 @@ export interface Event {
     [k: string]: unknown;
   } | null;
   featuredImage?: (number | null) | Media;
+  /**
+   * Automatically generated from name
+   */
+  slug?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -467,6 +471,7 @@ export interface EventsSelect<T extends boolean = true> {
   location?: T;
   description?: T;
   featuredImage?: T;
+  slug?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/queries/__tests__/getEventBySlug.test.ts
+++ b/src/queries/__tests__/getEventBySlug.test.ts
@@ -1,0 +1,69 @@
+// tests/queries/getEventBySlug.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getPayloadClient } from '@/lib/payload'
+import { getEventBySlug } from '@/queries/events'
+
+vi.mock('@/lib/payload', () => ({
+  getPayloadClient: vi.fn(),
+}))
+
+describe('getEventBySlug', () => {
+  const mockPayloadClient = {
+    find: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(getPayloadClient as any).mockResolvedValue(mockPayloadClient)
+  })
+
+  it('should return null if no event is found', async () => {
+    mockPayloadClient.find.mockResolvedValue({ docs: [] })
+
+    const result = await getEventBySlug('non-existent-event')
+
+    expect(mockPayloadClient.find).toHaveBeenCalledWith({
+      collection: 'events',
+      where: {
+        slug: { equals: 'non-existent-event' },
+      },
+    })
+    expect(result).toBeNull()
+  })
+
+  it('should return the event if found', async () => {
+    const mockEvent = {
+      id: '1',
+      title: 'Sample Event',
+      slug: 'sample-event',
+    }
+
+    mockPayloadClient.find.mockResolvedValue({ docs: [mockEvent] })
+
+    const result = await getEventBySlug('sample-event')
+
+    expect(mockPayloadClient.find).toHaveBeenCalledWith({
+      collection: 'events',
+      where: {
+        slug: { equals: 'sample-event' },
+      },
+    })
+    expect(result).toEqual(mockEvent)
+  })
+
+  it('should return null and log error if find throws', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockPayloadClient.find.mockRejectedValue(new Error('DB failure'))
+
+    const result = await getEventBySlug('failing-slug')
+
+    expect(result).toBeNull()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch event:',
+      expect.any(Error),
+    )
+
+    consoleSpy.mockRestore()
+  })
+})

--- a/src/queries/events.ts
+++ b/src/queries/events.ts
@@ -1,0 +1,21 @@
+import { getPayloadClient } from '@/lib/payload'
+import type { Event } from '@/payload-types'
+
+/**
+ * Get a event by its ID
+ * @param id - The ID of the event to get
+ * @returns The event
+ */
+export async function getEventBySlug(slug: string): Promise<Event | null> {
+  try {
+    const payload = await getPayloadClient()
+    const event = await payload.find({
+      collection: 'events',
+      where: { slug: { equals: slug } },
+    })
+    return event.docs[0] || null
+  } catch (error) {
+    console.error('Failed to fetch event:', error)
+    return null
+  }
+}


### PR DESCRIPTION
closes #37 

## 🌟 Context <!-- What is the purpose of this PR? -->

Linked to issue #37 
Linked to sprint 3
Create a basic single event page with loading, not-found and error fallbacks

---

## 📝 Description <!--What changes have been made? -->

Added pages: page, loading, not-found, error
Added components: EventPage, EventPageFallback
Added query for event/[slug]
Added unit tests for query
Edited events collection to include slug

---

## 📋 Notes <!--Are there any important details for reviewers? -->

<!--
-->
