### PR TITLE
Payload admin view improvements

### DIFF
--- a/src/app/(payload)/custom.scss
+++ b/src/app/(payload)/custom.scss
@@ -1,6 +1,19 @@
+// Hides filename
 .hide-filename {
   .file__filename {
     display: none !important;
   }
 }
 
+.show-first{
+  .relationship-cell {
+    // Hides all text nodes
+    font-size: 0;
+    line-height: 0;
+
+    // Hides everything except the first thumbnail
+    & > div:not(:first-child) {
+      display: none !important;
+    }
+  }
+}

--- a/src/app/(payload)/custom.scss
+++ b/src/app/(payload)/custom.scss
@@ -1,0 +1,6 @@
+.hide-filename {
+  .file__filename {
+    display: none !important;
+  }
+}
+

--- a/src/collections/events.ts
+++ b/src/collections/events.ts
@@ -23,14 +23,6 @@ export const Events: CollectionConfig = {
   },
   fields: [
     {
-      name: 'featuredImage',
-      type: 'upload',
-      relationTo: 'media',
-      admin: {
-        className: 'hide-filename',
-      },
-    },
-    {
       name: 'title',
       type: 'text',
       required: true,
@@ -72,6 +64,14 @@ export const Events: CollectionConfig = {
     {
       name: 'description',
       type: 'richText',
+    },
+    {
+      name: 'featuredImage',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        className: 'hide-filename',
+      },
     },
   ],
 }

--- a/src/collections/events.ts
+++ b/src/collections/events.ts
@@ -7,6 +7,13 @@ export const Events: CollectionConfig = {
   slug: 'events',
   admin: {
     useAsTitle: 'title',
+    defaultColumns: [
+      'featuredImage',
+      'title',
+      'status',
+      'startTime',
+      'endTime',
+    ],
   },
   access: {
     create: authenticated,
@@ -15,6 +22,14 @@ export const Events: CollectionConfig = {
     delete: authenticated,
   },
   fields: [
+    {
+      name: 'featuredImage',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        className: 'hide-filename',
+      },
+    },
     {
       name: 'title',
       type: 'text',
@@ -57,11 +72,6 @@ export const Events: CollectionConfig = {
     {
       name: 'description',
       type: 'richText',
-    },
-    {
-      name: 'featuredImage',
-      type: 'upload',
-      relationTo: 'media',
     },
   ],
 }

--- a/src/collections/events.ts
+++ b/src/collections/events.ts
@@ -5,6 +5,9 @@ import { authenticated } from '@/access/authenticated'
 
 export const Events: CollectionConfig = {
   slug: 'events',
+  admin: {
+    useAsTitle: 'title',
+  },
   access: {
     create: authenticated,
     read: anyone,

--- a/src/collections/execs.ts
+++ b/src/collections/execs.ts
@@ -7,6 +7,7 @@ export const Execs: CollectionConfig = {
   slug: 'execs',
   admin: {
     useAsTitle: 'name',
+    defaultColumns: ['image', 'name', 'role', 'email'],
   },
   access: {
     create: authenticated,
@@ -15,6 +16,15 @@ export const Execs: CollectionConfig = {
     delete: authenticated,
   },
   fields: [
+    {
+      name: 'image',
+      label: 'Profile Image',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        className: 'hide-filename',
+      },
+    },
     {
       name: 'name',
       label: 'Full Name',
@@ -37,12 +47,6 @@ export const Execs: CollectionConfig = {
       label: 'Email Address',
       type: 'email',
       required: true,
-    },
-    {
-      name: 'image',
-      label: 'Profile Image',
-      type: 'upload',
-      relationTo: 'media',
     },
   ],
 }

--- a/src/collections/execs.ts
+++ b/src/collections/execs.ts
@@ -17,15 +17,6 @@ export const Execs: CollectionConfig = {
   },
   fields: [
     {
-      name: 'image',
-      label: 'Profile Image',
-      type: 'upload',
-      relationTo: 'media',
-      admin: {
-        className: 'hide-filename',
-      },
-    },
-    {
       name: 'name',
       label: 'Full Name',
       type: 'text',
@@ -47,6 +38,15 @@ export const Execs: CollectionConfig = {
       label: 'Email Address',
       type: 'email',
       required: true,
+    },
+    {
+      name: 'image',
+      label: 'Profile Image',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        className: 'hide-filename',
+      },
     },
   ],
 }

--- a/src/collections/rivers.ts
+++ b/src/collections/rivers.ts
@@ -6,6 +6,9 @@ import { authenticated } from '@/access/authenticated'
 
 export const Rivers: CollectionConfig = {
   slug: 'rivers',
+  admin: {
+    useAsTitle: 'name',
+  },
   access: {
     create: authenticated,
     read: anyone,

--- a/src/collections/rivers.ts
+++ b/src/collections/rivers.ts
@@ -8,6 +8,7 @@ export const Rivers: CollectionConfig = {
   slug: 'rivers',
   admin: {
     useAsTitle: 'name',
+    defaultColumns: ['image', 'name', 'grade', 'description'],
   },
   access: {
     create: authenticated,
@@ -30,6 +31,14 @@ export const Rivers: CollectionConfig = {
   },
   fields: [
     {
+      name: 'image',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        className: 'hide-filename',
+      },
+    },
+    {
       name: 'name',
       type: 'text',
     },
@@ -40,11 +49,6 @@ export const Rivers: CollectionConfig = {
     {
       name: 'description',
       type: 'text',
-    },
-    {
-      name: 'image',
-      type: 'upload',
-      relationTo: 'media',
     },
     {
       name: 'slug',

--- a/src/collections/rivers.ts
+++ b/src/collections/rivers.ts
@@ -31,14 +31,6 @@ export const Rivers: CollectionConfig = {
   },
   fields: [
     {
-      name: 'image',
-      type: 'upload',
-      relationTo: 'media',
-      admin: {
-        className: 'hide-filename',
-      },
-    },
-    {
       name: 'name',
       type: 'text',
     },
@@ -60,6 +52,14 @@ export const Rivers: CollectionConfig = {
         readOnly: true,
         description: 'Automatically generated from name',
         hidden: true,
+      },
+    },
+    {
+      name: 'image',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        className: 'hide-filename',
       },
     },
   ],

--- a/src/collections/trip-reports.ts
+++ b/src/collections/trip-reports.ts
@@ -8,6 +8,7 @@ export const TripReports: CollectionConfig = {
   slug: 'trip-reports',
   admin: {
     useAsTitle: 'title',
+    defaultColumns: ['gallery', 'title', 'status', 'tripDate', 'location'],
   },
   access: {
     create: authenticated,
@@ -29,6 +30,16 @@ export const TripReports: CollectionConfig = {
     ],
   },
   fields: [
+    {
+      name: 'gallery',
+      type: 'upload',
+      hasMany: true,
+      relationTo: 'media',
+      label: 'Trip Gallery',
+      admin: {
+        className: 'hide-filename',
+      },
+    },
     {
       name: 'title',
       type: 'text',
@@ -75,13 +86,6 @@ export const TripReports: CollectionConfig = {
       required: false,
       relationTo: 'rivers',
       label: 'Related River',
-    },
-    {
-      name: 'gallery',
-      type: 'upload',
-      hasMany: true,
-      relationTo: 'media',
-      label: 'Trip Gallery',
     },
     {
       name: 'slug',

--- a/src/collections/trip-reports.ts
+++ b/src/collections/trip-reports.ts
@@ -31,16 +31,6 @@ export const TripReports: CollectionConfig = {
   },
   fields: [
     {
-      name: 'gallery',
-      type: 'upload',
-      hasMany: true,
-      relationTo: 'media',
-      label: 'Trip Gallery',
-      admin: {
-        className: 'hide-filename',
-      },
-    },
-    {
       name: 'title',
       type: 'text',
       required: true,
@@ -103,6 +93,16 @@ export const TripReports: CollectionConfig = {
       name: 'content',
       type: 'richText',
       label: 'Content',
+    },
+    {
+      name: 'gallery',
+      type: 'upload',
+      hasMany: true,
+      relationTo: 'media',
+      label: 'Trip Gallery',
+      admin: {
+        className: 'hide-filename show-first',
+      },
     },
   ],
 }

--- a/src/collections/trip-reports.ts
+++ b/src/collections/trip-reports.ts
@@ -6,6 +6,9 @@ import { authenticated } from '@/access/authenticated'
 
 export const TripReports: CollectionConfig = {
   slug: 'trip-reports',
+  admin: {
+    useAsTitle: 'title',
+  },
   access: {
     create: authenticated,
     read: anyone,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -217,10 +217,6 @@ export interface River {
 export interface Event {
   id: number;
   title: string;
-  /**
-   * Automatically generated from title
-   */
-  slug?: string | null;
   status: 'draft' | 'published' | 'archived';
   startTime: string;
   endTime?: string | null;
@@ -465,7 +461,6 @@ export interface RiversSelect<T extends boolean = true> {
  */
 export interface EventsSelect<T extends boolean = true> {
   title?: T;
-  slug?: T;
   status?: T;
   startTime?: T;
   endTime?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -199,10 +199,10 @@ export interface Media {
  */
 export interface River {
   id: number;
+  image?: (number | null) | Media;
   name?: string | null;
   grade?: number | null;
   description?: string | null;
-  image?: (number | null) | Media;
   /**
    * Automatically generated from name
    */
@@ -216,6 +216,7 @@ export interface River {
  */
 export interface Event {
   id: number;
+  featuredImage?: (number | null) | Media;
   title: string;
   status: 'draft' | 'published' | 'archived';
   startTime: string;
@@ -236,7 +237,6 @@ export interface Event {
     };
     [k: string]: unknown;
   } | null;
-  featuredImage?: (number | null) | Media;
   updatedAt: string;
   createdAt: string;
 }
@@ -246,6 +246,7 @@ export interface Event {
  */
 export interface TripReport {
   id: number;
+  gallery?: (number | Media)[] | null;
   title: string;
   status: 'draft' | 'published';
   author: (number | Exec)[];
@@ -253,7 +254,6 @@ export interface TripReport {
   location?: string | null;
   relatedEvent?: (number | null) | Event;
   relatedRiver?: (number | null) | River;
-  gallery?: (number | Media)[] | null;
   /**
    * Automatically generated from title
    */
@@ -282,11 +282,11 @@ export interface TripReport {
  */
 export interface Exec {
   id: number;
+  image?: (number | null) | Media;
   name: string;
   pronouns?: string | null;
   role: string;
   email: string;
-  image?: (number | null) | Media;
   updatedAt: string;
   createdAt: string;
 }
@@ -447,10 +447,10 @@ export interface MediaSelect<T extends boolean = true> {
  * via the `definition` "rivers_select".
  */
 export interface RiversSelect<T extends boolean = true> {
+  image?: T;
   name?: T;
   grade?: T;
   description?: T;
-  image?: T;
   slug?: T;
   updatedAt?: T;
   createdAt?: T;
@@ -460,13 +460,13 @@ export interface RiversSelect<T extends boolean = true> {
  * via the `definition` "events_select".
  */
 export interface EventsSelect<T extends boolean = true> {
+  featuredImage?: T;
   title?: T;
   status?: T;
   startTime?: T;
   endTime?: T;
   location?: T;
   description?: T;
-  featuredImage?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -475,6 +475,7 @@ export interface EventsSelect<T extends boolean = true> {
  * via the `definition` "trip-reports_select".
  */
 export interface TripReportsSelect<T extends boolean = true> {
+  gallery?: T;
   title?: T;
   status?: T;
   author?: T;
@@ -482,7 +483,6 @@ export interface TripReportsSelect<T extends boolean = true> {
   location?: T;
   relatedEvent?: T;
   relatedRiver?: T;
-  gallery?: T;
   slug?: T;
   content?: T;
   updatedAt?: T;
@@ -493,11 +493,11 @@ export interface TripReportsSelect<T extends boolean = true> {
  * via the `definition` "execs_select".
  */
 export interface ExecsSelect<T extends boolean = true> {
+  image?: T;
   name?: T;
   pronouns?: T;
   role?: T;
   email?: T;
-  image?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -199,7 +199,6 @@ export interface Media {
  */
 export interface River {
   id: number;
-  image?: (number | null) | Media;
   name?: string | null;
   grade?: number | null;
   description?: string | null;
@@ -207,6 +206,7 @@ export interface River {
    * Automatically generated from name
    */
   slug?: string | null;
+  image?: (number | null) | Media;
   updatedAt: string;
   createdAt: string;
 }
@@ -216,7 +216,6 @@ export interface River {
  */
 export interface Event {
   id: number;
-  featuredImage?: (number | null) | Media;
   title: string;
   status: 'draft' | 'published' | 'archived';
   startTime: string;
@@ -237,6 +236,7 @@ export interface Event {
     };
     [k: string]: unknown;
   } | null;
+  featuredImage?: (number | null) | Media;
   updatedAt: string;
   createdAt: string;
 }
@@ -246,7 +246,6 @@ export interface Event {
  */
 export interface TripReport {
   id: number;
-  gallery?: (number | Media)[] | null;
   title: string;
   status: 'draft' | 'published';
   author: (number | Exec)[];
@@ -273,6 +272,7 @@ export interface TripReport {
     };
     [k: string]: unknown;
   } | null;
+  gallery?: (number | Media)[] | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -282,11 +282,11 @@ export interface TripReport {
  */
 export interface Exec {
   id: number;
-  image?: (number | null) | Media;
   name: string;
   pronouns?: string | null;
   role: string;
   email: string;
+  image?: (number | null) | Media;
   updatedAt: string;
   createdAt: string;
 }
@@ -447,11 +447,11 @@ export interface MediaSelect<T extends boolean = true> {
  * via the `definition` "rivers_select".
  */
 export interface RiversSelect<T extends boolean = true> {
-  image?: T;
   name?: T;
   grade?: T;
   description?: T;
   slug?: T;
+  image?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -460,13 +460,13 @@ export interface RiversSelect<T extends boolean = true> {
  * via the `definition` "events_select".
  */
 export interface EventsSelect<T extends boolean = true> {
-  featuredImage?: T;
   title?: T;
   status?: T;
   startTime?: T;
   endTime?: T;
   location?: T;
   description?: T;
+  featuredImage?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -475,7 +475,6 @@ export interface EventsSelect<T extends boolean = true> {
  * via the `definition` "trip-reports_select".
  */
 export interface TripReportsSelect<T extends boolean = true> {
-  gallery?: T;
   title?: T;
   status?: T;
   author?: T;
@@ -485,6 +484,7 @@ export interface TripReportsSelect<T extends boolean = true> {
   relatedRiver?: T;
   slug?: T;
   content?: T;
+  gallery?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -493,11 +493,11 @@ export interface TripReportsSelect<T extends boolean = true> {
  * via the `definition` "execs_select".
  */
 export interface ExecsSelect<T extends boolean = true> {
-  image?: T;
   name?: T;
   pronouns?: T;
   role?: T;
   email?: T;
+  image?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
closes #49 

## 🌟 Context <!-- What is the purpose of this PR? -->

Improvements to the admin view of payload collections to improve UX/UI

---

## 📝 Description <!--What changes have been made? -->

Filename next to is conditionally hidden and image is moved to first column for trip reports, execs, events, rivers
Display names changed from ID to title, with ID now being hidden 

---

## 📋 Notes <!--Are there any important details for reviewers? -->

changed custom.scss, hopefully this is fine
