### PR TITLE
Adding a Cover Image field to the Trip Report collection

### DIFF
--- a/src/app/(frontend)/trip-reports/_components/TripReportCard.tsx
+++ b/src/app/(frontend)/trip-reports/_components/TripReportCard.tsx
@@ -6,6 +6,8 @@ import { getPlainText } from '@/lib/utils/get-plain-text'
 import { TripReport } from '@/payload-types'
 import type { Exec } from '@/payload-types'
 
+const PLACEHOLDER = '/hero_background_Image.jpg'
+
 export interface TripReportCardProps {
   report: TripReport
 }
@@ -16,8 +18,10 @@ function isExec(a: number | Exec): a is Exec {
 
 export function TripReportCard({ report }: TripReportCardProps) {
   const postAuthors = report.author.filter(isExec)
-  const galleryItems = report.gallery as { url: string }[] | undefined
-  const coverImage = galleryItems?.[0]?.url
+  const coverImage =
+    report.coverImage && typeof report.coverImage !== 'number'
+      ? report.coverImage.url
+      : PLACEHOLDER
 
   return (
     <Link
@@ -35,7 +39,6 @@ export function TripReportCard({ report }: TripReportCardProps) {
           />
         </div>
       )}
-
       <h3 className="mb-1 text-lg font-semibold">{report.title}</h3>
       {report.tripDate && (
         <p className="mb-1 text-sm text-gray-500">
@@ -50,7 +53,6 @@ export function TripReportCard({ report }: TripReportCardProps) {
           By {postAuthors.map((a) => a.name).join(', ')}
         </p>
       )}
-
       {report.content && (
         <div className="mt-1 line-clamp-2 text-sm whitespace-pre-wrap text-gray-600">
           {getPlainText(report.content)}

--- a/src/collections/trip-reports.ts
+++ b/src/collections/trip-reports.ts
@@ -10,7 +10,14 @@ export const TripReports: CollectionConfig = {
   slug: 'trip-reports',
   admin: {
     useAsTitle: 'title',
-    defaultColumns: ['gallery', 'title', 'status', 'tripDate', 'location'],
+    defaultColumns: [
+      'coverImage',
+      'gallery',
+      'title',
+      'status',
+      'tripDate',
+      'location',
+    ],
   },
   access: {
     create: authenticated,
@@ -89,6 +96,16 @@ export const TripReports: CollectionConfig = {
       mimeType: 'image',
       admin: {
         className: 'hide-filename show-first',
+      },
+    }),
+    customUploadField({
+      name: 'coverImage',
+      label: 'Cover Image',
+      hasMany: false,
+      required: false,
+      mimeType: 'image',
+      admin: {
+        thumbnail: true,
       },
     }),
     {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -258,6 +258,7 @@ export interface TripReport {
   relatedEvent?: (number | null) | Event;
   relatedRiver?: (number | null) | River;
   gallery: (number | Media)[];
+  coverImage?: (number | null) | Media;
   /**
    * Automatically generated from title
    */
@@ -516,6 +517,7 @@ export interface TripReportsSelect<T extends boolean = true> {
   relatedEvent?: T;
   relatedRiver?: T;
   gallery?: T;
+  coverImage?: T;
   slug?: T;
   content?: T;
   updatedAt?: T;


### PR DESCRIPTION
Does not close a specific ticket, but is a dependency of #83 and #38 and #53 

## 🌟 Context <!-- What is the purpose of this PR? -->

<!--
Link to related issues, user stories, or tasks: #<issue_number>
Mention relevant sprints or milestones.
Describe the main goal of this change and why it's needed
Include any business context or requirements driving this change
-->

This changes affects what makes a trip report by adding a new Cover Image field that is used when displaying trip reports on the web UI.

---

## 📝 Description <!--What changes have been made? -->

<!--
Briefly describe key updates — new features, bug fixes, or refactors.
Highlight any important design or architectural decisions.
Explain how these changes address the issue/requirement
Include any dependencies that are required for this change
-->

There are two parts to this change:

1) The collection in trip reports has been modified with a new Cover Image customUploadField that is not mandatory and that is unique. 

2) If there is no cover image supplied with the trip report, the front end handles this by replacing what the cover Image would be by a placeholder that is stored in the public folder in the web app

---

## 📋 Notes <!--Are there any important details for reviewers? -->

This may affect people's database schemas. If that is the case,  if troubleshooting is not enough, Franck apparently used a command to redo the migrations for the DB when he had such an issue. The command was along the lines of payload: migrate. 
