### PR TITLE
Gallery section mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
     "graphql": "^16.8.1",
+    "keen-slider": "^6.8.6",
     "leaflet": "^1.9.4",
     "leaflet-defaulticon-compatibility": "^0.1.2",
     "lucide-react": "^0.477.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.10.0
+      keen-slider:
+        specifier: ^6.8.6
+        version: 6.8.6
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -4662,6 +4665,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  keen-slider@6.8.6:
+    resolution: {integrity: sha512-dcEQ7GDBpCjUQA8XZeWh3oBBLLmyn8aoeIQFGL/NTVkoEOsmlnXqA4QykUm/SncolAZYGsEk/PfUhLZ7mwMM2w==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -12010,6 +12016,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  keen-slider@6.8.6: {}
 
   keyv@4.5.4:
     dependencies:

--- a/src/app/(frontend)/_components/home/gallery/GallerySection.tsx
+++ b/src/app/(frontend)/_components/home/gallery/GallerySection.tsx
@@ -1,10 +1,23 @@
+import { getGallery } from '@/queries/gallery'
 import { GalleryTopCurve } from './GalleryTopCurve'
+import GallerySlider from './ImageSlider'
+import { SEGButton } from './SEGButton'
 
-export function GallerySection() {
+export async function GallerySection() {
+  const { gallery } = await getGallery({ limit: 10 })
+
   return (
     <div className="relative bg-linear-198 from-[#D4E2DA] from-30% to-[#FCF9EF]">
       <GalleryTopCurve className="max-h-40 -translate-y-px" />
-      <div className="min-h-96">Gallery Section</div>
+
+      <div>
+        <h1 className="font-heading text-grass pt-16 pb-8 text-center text-3xl tracking-tighter">
+          Gallery
+        </h1>
+        <GallerySlider gallery={gallery} />
+
+        <SEGButton />
+      </div>
     </div>
   )
 }

--- a/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
+++ b/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
@@ -11,15 +11,32 @@ type Props = {
 }
 
 export default function GallerySlider({ gallery }: Props) {
-  const [sliderRef] = useKeenSlider<HTMLDivElement>({
-    loop: true,
-    mode: 'snap',
-    slides: {
-      perView: 1.1,
-      spacing: 12,
-      origin: 'center',
+  const [sliderRef] = useKeenSlider<HTMLDivElement>(
+    {
+      loop: true,
+      mode: 'snap',
+      slides: {
+        perView: 1.1,
+        spacing: 12,
+        origin: 'center',
+      },
     },
-  })
+    [
+      (slider) => {
+        let timeout: ReturnType<typeof setTimeout>
+
+        const nextTimeout = () => {
+          clearTimeout(timeout)
+          timeout = setTimeout(() => {
+            slider.next()
+          }, 6000)
+        }
+        slider.on('created', nextTimeout)
+        slider.on('dragStarted', () => clearTimeout(timeout))
+        slider.on('animationEnded', nextTimeout)
+      },
+    ],
+  )
 
   return (
     <div>

--- a/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
+++ b/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
@@ -4,6 +4,8 @@ import { useKeenSlider } from 'keen-slider/react'
 
 import 'keen-slider/keen-slider.min.css'
 
+import Image from 'next/image'
+
 import type { GalleryDTO } from '@/queries/gallery'
 
 type Props = {
@@ -48,11 +50,14 @@ export default function GallerySlider({ gallery }: Props) {
           return (
             <div key={item.id} className="keen-slider__slide">
               {src ? (
-                <img
-                  src={src}
-                  alt={media?.alt || ''}
-                  className="aspect-[4/3] w-full object-cover"
-                />
+                <div className="relative aspect-[4/3] w-full">
+                  <Image
+                    src={src}
+                    alt={media?.alt || ''}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
               ) : (
                 <div>Image not available</div>
               )}

--- a/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
+++ b/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useKeenSlider } from 'keen-slider/react'
+
+import 'keen-slider/keen-slider.min.css'
+
+import type { GalleryDTO } from '@/queries/gallery'
+
+type Props = {
+  gallery: GalleryDTO[]
+}
+
+export default function GallerySlider({ gallery }: Props) {
+  const [sliderRef] = useKeenSlider<HTMLDivElement>({
+    loop: true,
+    mode: 'snap',
+    slides: {
+      perView: 1.1,
+      spacing: 12,
+      origin: 'center',
+    },
+  })
+
+  return (
+    <div>
+      <div ref={sliderRef} className="keen-slider">
+        {gallery.map((item, i) => {
+          const media = item.image
+          const src = media?.url || ''
+
+          return (
+            <div key={item.id} className="keen-slider__slide">
+              {src ? (
+                <img
+                  src={src}
+                  alt={media?.alt || ''}
+                  className="aspect-[4/3] w-full object-cover"
+                />
+              ) : (
+                <div>Image not available</div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/_components/home/gallery/SEGButton.tsx
+++ b/src/app/(frontend)/_components/home/gallery/SEGButton.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+
+export function SEGButton() {
+  return (
+    <Link
+      href="/gallery"
+      className="flex items-center justify-center pt-8 pb-16"
+    >
+      <button className="font-unbounded text-abyss flex items-center justify-center gap-2 text-sm tracking-tighter">
+        SEE ENTIRE GALLERY
+        <ArrowRight />
+      </button>
+    </Link>
+  )
+}

--- a/src/lib/utils/revalidation.ts
+++ b/src/lib/utils/revalidation.ts
@@ -23,6 +23,7 @@ const tagRelations = {
   media: [],
   rivers: ['media'],
   tripReports: ['media'],
+  gallery: ['media'],
 } as const
 
 /** 
@@ -64,6 +65,10 @@ export const cacheTags: Record<
   tripReports: {
     relatedTags: getRevalidationTags('tripReports'),
     revalidate: () => revalidateTag('tripReports'),
+  },
+  gallery: {
+    relatedTags: getRevalidationTags('gallery'),
+    revalidate: () => revalidateTag('gallery'),
   },
 }
 

--- a/src/queries/gallery.ts
+++ b/src/queries/gallery.ts
@@ -1,0 +1,48 @@
+import { unstable_cache } from 'next/cache'
+
+import { getPayloadClient } from '@/lib/payload'
+import { cacheTags } from '@/lib/utils/revalidation'
+import { NoNumber } from '@/lib/utils/util-types'
+import { Gallery } from '@/payload-types'
+
+export type GalleryDTO = NoNumber<Gallery>
+
+/**
+ * Get all gallery items
+ * @param page - The page number to get
+ * @param limit - The number of items to get per page
+ * @param sort - The field to sort the items by
+ * @returns The gallery items and pagination information
+ */
+export const getGallery = unstable_cache(
+  async function ({
+    page = 1,
+    limit = 10,
+    sort = '-createdAt',
+  }: {
+    page?: number
+    limit?: number
+    sort?: string
+  } = {}) {
+    const payload = await getPayloadClient()
+
+    const { docs, hasNextPage, nextPage, totalDocs } = await payload.find({
+      collection: 'gallery',
+      page,
+      limit,
+      sort,
+      depth: 1,
+    })
+
+    return {
+      gallery: docs as GalleryDTO[],
+      hasNextPage,
+      nextPage,
+      totalDocs,
+    }
+  },
+  ['getGallery'],
+  {
+    tags: cacheTags.gallery.relatedTags,
+  },
+)


### PR DESCRIPTION
closes #81 

## 🌟 Context <!-- What is the purpose of this PR? -->

Gallery section for mobile users

---

## 📝 Description <!--What changes have been made? -->

Gallery section modified
- Image slider added, draggable and autoplay
- Gallery link added
- Styling matches figma mobile design
- Gallery query created for getting all gallery items
- Gallery revalidation hook added

---

## 📋 Notes <!--Are there any important details for reviewers? -->

Current autoplay is set to 6 seconds, and pauses and resets when being dragged. Pls weigh in on if you agree with this.

Current image slider uses Keen-Slider as a lightweight, mobile-friendly library
