### PR TITLE
Improve admin gallery

### DIFF
--- a/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
+++ b/src/app/(frontend)/_components/home/gallery/ImageSlider.tsx
@@ -120,7 +120,7 @@ export default function GallerySlider({ gallery }: Props) {
     <div className="relative">
       <div ref={sliderRef} className="keen-slider">
         {gallery.map((item) => {
-          const media = item.image
+          const media = item.image[0]
           const src = media?.url || ''
 
           return (

--- a/src/collections/components/CustomUploadButton.tsx
+++ b/src/collections/components/CustomUploadButton.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import React from 'react'
+import type { ListViewClientProps } from 'payload'
+
+// Experimental file for bulk creating items in the gallery, not done, doesnt work, not used
+
+function CustomUpload() {
+  return <div>Custom Upload Component</div>
+}
+
+export default function CustomUploadButton(props: ListViewClientProps) {
+  console.log(props)
+  return (
+    // <button
+    //   type="button"
+    //   aria-label="Bulk Upload"
+    //   class="btn btn--icon-style-without-border btn--size-small btn--withoutPopup btn--style-pill btn--withoutPopup"
+    // >
+    //   <span class="btn__content">
+    //     <span class="btn__label">Bulk Upload</span>
+    //   </span>
+    // </button>
+    <>
+      <div hidden id="yes" className="absolute h-full">
+        <div className="bulk-upload--add-files">
+          <div className="bulk-upload--drawer-header">
+            <h2 title="Add files">Add files</h2>
+            <button
+              aria-label="Close"
+              className="drawer-close-button"
+              type="button"
+            >
+              <svg
+                className="icon icon--x"
+                height="20"
+                viewBox="0 0 20 20"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  className="stroke"
+                  d="M14 6L6 14M6 6L14 14"
+                  strokeLinecap="square"
+                ></path>
+              </svg>
+            </button>
+          </div>
+          <div className="bulk-upload--add-files__dropArea">
+            <div className="dropzone dropzoneStyle--default">
+              <button
+                type="button"
+                className="btn btn--icon-style-without-border btn--size-small btn--withoutPopup btn--style-pill btn--withoutPopup"
+              >
+                <span className="btn__content">
+                  <span className="btn__label">Select a file</span>
+                </span>
+              </button>
+              <input
+                aria-hidden="true"
+                className="bulk-upload--add-files__hidden-input"
+                hidden
+                multiple
+                type="file"
+              />
+              <p className="bulk-upload--add-files__dragAndDropText">
+                Or Drag and drop a file
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="btn btn--icon-style-without-border btn--size-small btn--withoutPopup btn--style-pill"
+        onClick={() => {
+          document.getElementById('yes')!.toggleAttribute('hidden')
+        }}
+      >
+        <span className="btn__content">
+          <span className="btn__label">Bulk Upload</span>
+        </span>
+      </button>
+    </>
+  )
+}

--- a/src/collections/gallery.ts
+++ b/src/collections/gallery.ts
@@ -22,9 +22,9 @@ export const Gallery: CollectionConfig = {
   hooks: {
     afterChange: [
       ({ doc, req }) => {
-        if (doc['more-images'].length > 0) {
+        if (doc['image'].length > 1) {
           if (req.payload) {
-            doc['more-images'].forEach((item: any) => {
+            doc['image'].slice(1).forEach((item: any) => {
               req.payload.create({
                 collection: 'gallery',
                 data: {
@@ -38,7 +38,7 @@ export const Gallery: CollectionConfig = {
             collection: 'gallery',
             id: doc.id,
             data: {
-              'more-images': [],
+              image: doc['image'][0],
             },
           })
         }
@@ -56,16 +56,6 @@ export const Gallery: CollectionConfig = {
       name: 'image',
       label: 'Image',
       required: true,
-      mimeType: 'image',
-      admin: {
-        thumbnail: true,
-        className: 'hide-filename',
-      },
-    }),
-    customUploadField({
-      name: 'more-images',
-      label: 'Image',
-      required: false,
       mimeType: 'image',
       admin: {
         thumbnail: true,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -331,8 +331,7 @@ export interface Exec {
  */
 export interface Gallery {
   id: number;
-  image: number | Media;
-  'more-images'?: (number | Media)[] | null;
+  image: (number | Media)[];
   tags?: (number | Tag)[] | null;
   updatedAt: string;
   createdAt: string;
@@ -607,7 +606,6 @@ export interface ExecsSelect<T extends boolean = true> {
  */
 export interface GallerySelect<T extends boolean = true> {
   image?: T;
-  'more-images'?: T;
   tags?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -332,6 +332,7 @@ export interface Exec {
 export interface Gallery {
   id: number;
   image: number | Media;
+  'more-images'?: (number | Media)[] | null;
   tags?: (number | Tag)[] | null;
   updatedAt: string;
   createdAt: string;
@@ -606,6 +607,7 @@ export interface ExecsSelect<T extends boolean = true> {
  */
 export interface GallerySelect<T extends boolean = true> {
   image?: T;
+  'more-images'?: T;
   tags?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
closes #116

## 🌟 Context <!-- What is the purpose of this PR? -->

<!--
Link to related issues, user stories, or tasks: #<issue_number>
Mention relevant sprints or milestones.
Describe the main goal of this change and why it's needed
Include any business context or requirements driving this change
-->

The current gallery collection does not allow bulk create, making the process of submitting multiple images for gallery tedious.

---

## 📝 Description <!--What changes have been made? -->

<!--
Briefly describe key updates — new features, bug fixes, or refactors.
Highlight any important design or architectural decisions.
Explain how these changes address the issue/requirement
Include any dependencies that are required for this change
-->

Makes the required image field of gallery an array that can take multiple images.  Only one image will be kept and the rest will be used to create more gallery items with the same tag.

---

## 📋 Notes <!--Are there any important details for reviewers? -->

<!--
Potential risks or breaking changes.
Edge cases or areas requiring special attention.
Anything you want feedback on!
List any manual testing you've performed
Mention any documentation that needs updating as a result
-->

The 'CustomUploadButton.tsx' file is created as an experiment to see what a custom component could look like, uncomment the component section in gallery section to see it.

