### PR TITLE
added the client side image filter for the gallery page

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@storybook/addon-docs": "^9.0.2",
     "@storybook/nextjs-vite": "9.0.2",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.3",
     "@types/leaflet": "1.9.18",
     "@types/node": "^22.5.4",
     "@types/react": "19.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.3
+        version: 14.6.3(@testing-library/dom@10.4.0)
       '@types/leaflet':
         specifier: 1.9.18
         version: 1.9.18
@@ -2865,8 +2868,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@testing-library/user-event@14.6.1':
-    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+  '@testing-library/user-event@14.6.3':
+    resolution: {integrity: sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -10068,7 +10071,7 @@ snapshots:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+  '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
 
@@ -10299,7 +10302,7 @@ snapshots:
   '@vitest/browser@3.1.2(msw@2.7.5(@types/node@22.13.13)(typescript@5.7.3))(playwright@1.52.0)(vite@6.3.2(@types/node@22.13.13)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.77.4)(terser@5.39.2)(tsx@4.20.6)(yaml@2.7.1))(vitest@3.1.2)':
     dependencies:
       '@testing-library/dom': 10.4.0
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.0)
       '@vitest/mocker': 3.1.2(msw@2.7.5(@types/node@22.13.13)(typescript@5.7.3))(vite@6.3.2(@types/node@22.13.13)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.77.4)(terser@5.39.2)(tsx@4.20.6)(yaml@2.7.1))
       '@vitest/utils': 3.1.2
       magic-string: 0.30.17
@@ -13520,7 +13523,7 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.3
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.0.9
       '@vitest/spy': 3.0.9
       better-opn: 3.0.2

--- a/src/app/(frontend)/gallery/_components/ImagesFromPayload.tsx
+++ b/src/app/(frontend)/gallery/_components/ImagesFromPayload.tsx
@@ -1,6 +1,6 @@
 import { getPayloadClient } from '@/lib/payload'
 import type { Media } from '@/payload-types'
-import { GalleryGrid } from './gallery-images/GalleryGrid'
+import { FilterableGalleryGrid } from './gallery-images/FilterableGalleryGrid'
 import { NoImages } from './gallery-images/GalleryImage'
 
 export async function ImagesFromPayload() {
@@ -16,12 +16,19 @@ export async function ImagesFromPayload() {
       (doc): doc is typeof doc & { image: Media } =>
         typeof doc.image !== 'number',
     )
-    .map((doc) => ({
+    .map((doc, index) => ({
       src: doc.image.url ?? '',
       alt: doc.image.alt ?? '',
+      // TEMP: fake varied tags to test filtering — REVERT before committing
+      tags: ['Taupo', 'Fulljames', 'Waikato River', 'Test Tag'].slice(
+        0,
+        (index % 4) + 1,
+      ),
     }))
+
   if (images.length === 0) {
     return <NoImages />
   }
-  return <GalleryGrid images={images} />
+
+  return <FilterableGalleryGrid images={images} />
 }

--- a/src/app/(frontend)/gallery/_components/gallery-images/FilterableGalleryGrid.tsx
+++ b/src/app/(frontend)/gallery/_components/gallery-images/FilterableGalleryGrid.tsx
@@ -100,7 +100,7 @@ function FilterIcon() {
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="h-5 w-5"
+      className="h-7 w-7"
     >
       <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
     </svg>

--- a/src/app/(frontend)/gallery/_components/gallery-images/FilterableGalleryGrid.tsx
+++ b/src/app/(frontend)/gallery/_components/gallery-images/FilterableGalleryGrid.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { GalleryGrid } from './GalleryGrid'
+import { NoImages } from './GalleryImage'
+
+type GalleryImageItem = {
+  src: string
+  alt: string
+  tags: string[]
+}
+
+type FilterableGalleryGridProps = {
+  images: GalleryImageItem[]
+}
+
+export function FilterableGalleryGrid({ images }: FilterableGalleryGridProps) {
+  const [isPanelOpen, setIsPanelOpen] = useState(false)
+  const [activeFilter, setActiveFilter] = useState<string | null>(null)
+
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>()
+    images.forEach((image) => image.tags.forEach((tag) => tagSet.add(tag)))
+    return Array.from(tagSet).sort()
+  }, [images])
+
+  const filteredImages = useMemo(() => {
+    if (!activeFilter) return images
+    return images.filter((image) => image.tags.includes(activeFilter))
+  }, [images, activeFilter])
+
+  function handleSelectFilter(tag: string | null) {
+    setActiveFilter(tag)
+    setIsPanelOpen(false)
+  }
+
+  return (
+    <div className="relative">
+      <div className="mb-4 flex justify-end">
+        <button
+          type="button"
+          onClick={() => setIsPanelOpen((open) => !open)}
+          aria-label="Filter gallery images"
+          aria-expanded={isPanelOpen}
+          className="rounded-full p-2 hover:bg-gray-100"
+        >
+          <FilterIcon />
+        </button>
+      </div>
+
+      {isPanelOpen && (
+        <div className="absolute top-12 right-0 z-10 flex min-w-[160px] flex-col gap-1 rounded-lg border bg-white p-3 shadow-lg">
+          <button
+            type="button"
+            onClick={() => handleSelectFilter(null)}
+            className={`rounded px-3 py-1.5 text-left ${
+              activeFilter === null
+                ? 'bg-gray-100 font-medium'
+                : 'hover:bg-gray-50'
+            }`}
+          >
+            All
+          </button>
+          {availableTags.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => handleSelectFilter(tag)}
+              className={`rounded px-3 py-1.5 text-left ${
+                activeFilter === tag
+                  ? 'bg-gray-100 font-medium'
+                  : 'hover:bg-gray-50'
+              }`}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {filteredImages.length === 0 ? (
+        <NoImages />
+      ) : (
+        <GalleryGrid
+          images={filteredImages.map(({ src, alt }) => ({ src, alt }))}
+        />
+      )}
+    </div>
+  )
+}
+
+function FilterIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-5 w-5"
+    >
+      <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+    </svg>
+  )
+}

--- a/src/app/(frontend)/gallery/tests/FilterableGalleryGrid.test.tsx
+++ b/src/app/(frontend)/gallery/tests/FilterableGalleryGrid.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { FilterableGalleryGrid } from '../_components/gallery-images/FilterableGalleryGrid'
+import { NO_IMAGES_EMPTY_STATE_COPY } from '../_components/gallery-images/GalleryImage'
+
+const mockImages = [
+  { src: '/image1.jpg', alt: 'Image 1', tags: ['Taupo', 'Fulljames'] },
+  { src: '/image2.jpg', alt: 'Image 2', tags: ['Taupo'] },
+  { src: '/image3.jpg', alt: 'Image 3', tags: ['Wairoa'] },
+]
+
+describe('FilterableGalleryGrid', () => {
+  it('renders all images by default', () => {
+    render(<FilterableGalleryGrid images={mockImages} />)
+    expect(screen.getAllByRole('img')).toHaveLength(3)
+  })
+
+  it('renders the empty state when images is empty', () => {
+    render(<FilterableGalleryGrid images={[]} />)
+
+    expect(screen.getByTestId('gallery-empty-state')).not.toBeNull()
+    expect(screen.getByText(NO_IMAGES_EMPTY_STATE_COPY)).not.toBeNull()
+  })
+
+  it('opens the filter panel when the filter icon is clicked', async () => {
+    const user = userEvent.setup()
+    render(<FilterableGalleryGrid images={mockImages} />)
+
+    expect(screen.queryByText('All')).toBeNull()
+
+    await user.click(screen.getByLabelText('Filter gallery images'))
+
+    expect(screen.getByText('All')).not.toBeNull()
+  })
+
+  it('lists every unique tag as a filter option', async () => {
+    const user = userEvent.setup()
+    render(<FilterableGalleryGrid images={mockImages} />)
+
+    await user.click(screen.getByLabelText('Filter gallery images'))
+
+    expect(screen.getByText('Taupo')).not.toBeNull()
+    expect(screen.getByText('Fulljames')).not.toBeNull()
+    expect(screen.getByText('Wairoa')).not.toBeNull()
+  })
+
+  it('deduplicates repeated tags across images', async () => {
+    const user = userEvent.setup()
+    render(<FilterableGalleryGrid images={mockImages} />)
+
+    await user.click(screen.getByLabelText('Filter gallery images'))
+
+    expect(screen.getAllByText('Taupo')).toHaveLength(1)
+  })
+
+  it('filters images by selected tag', async () => {
+    const user = userEvent.setup()
+    render(<FilterableGalleryGrid images={mockImages} />)
+
+    await user.click(screen.getByLabelText('Filter gallery images'))
+    await user.click(screen.getByText('Wairoa'))
+
+    expect(screen.getAllByRole('img')).toHaveLength(1)
+    expect(screen.getByAltText('Image 3')).not.toBeNull()
+  })
+
+  it('restores all images when "All" is selected after filtering', async () => {
+    const user = userEvent.setup()
+    render(<FilterableGalleryGrid images={mockImages} />)
+
+    await user.click(screen.getByLabelText('Filter gallery images'))
+    await user.click(screen.getByText('Wairoa'))
+    expect(screen.getAllByRole('img')).toHaveLength(1)
+
+    await user.click(screen.getByLabelText('Filter gallery images'))
+    await user.click(screen.getByText('All'))
+
+    expect(screen.getAllByRole('img')).toHaveLength(3)
+  })
+
+  it('closes the filter panel after selecting a tag', async () => {
+    const user = userEvent.setup()
+    render(<FilterableGalleryGrid images={mockImages} />)
+
+    await user.click(screen.getByLabelText('Filter gallery images'))
+    await user.click(screen.getByText('Taupo'))
+
+    expect(screen.queryByText('All')).toBeNull()
+  })
+})

--- a/src/app/(frontend)/gallery/tests/GalleryGrid.test.tsx
+++ b/src/app/(frontend)/gallery/tests/GalleryGrid.test.tsx
@@ -41,6 +41,7 @@ describe('GalleryGrid', () => {
     const noImagesText = screen.queryByTestId('gallery-empty-state')
     expect(noImagesText).toBeNull()
   })
+
   it(' has the expected responsive Tailwind class names', () => {
     const images = [
       { src: '/image1.jpg', alt: 'Image 1' },


### PR DESCRIPTION
closes #<issue_number>

## 🌟 Context <!-- What is the purpose of this PR? -->

to create a client side filter for the gallery images

---

## 📝 Description <!--What changes have been made? -->

essentially made the filter button, and allowed for the images to be filtered by their specific tags
---

## 📋 Notes <!--Are there any important details for reviewers? -->

there are a couple things, mainly how there is currently changes to the image tags. To make sure that the filter actually works I had to change the tags manually for all the images (so they currently just have random tags), this is because they all had the exact same tags already, so filtering did nothing. would be happy to remove that and the test tag after it's all be checked.
