### PR TITLE
Guard Intersection Observer From Loading Instantly

### DIFF
--- a/src/app/(frontend)/gallery/_components/gallery-images/GalleryGrid.test.tsx
+++ b/src/app/(frontend)/gallery/_components/gallery-images/GalleryGrid.test.tsx
@@ -58,7 +58,6 @@ function mockPayloadResponse(
 
 beforeEach(() => {
   IntersectionObserverMock.instances = []
-  // @ts-expect-error - test mock
   global.IntersectionObserver = IntersectionObserverMock
   global.fetch = vi.fn()
 })
@@ -78,7 +77,9 @@ describe('GalleryGrid infinite scroll', () => {
     )
 
     render(<GalleryGrid initialImages={initialImages} initialHasMore={true} />)
-    latestObserver().trigger()
+    const observer = latestObserver()
+    observer.trigger() // mandatory initial callback — ignored by the guard
+    observer.trigger() // real scroll-triggered intersection
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/gallery?page=2&limit=12')
@@ -94,7 +95,9 @@ describe('GalleryGrid infinite scroll', () => {
     )
 
     render(<GalleryGrid initialImages={initialImages} initialHasMore={true} />)
-    latestObserver().trigger()
+    const observer = latestObserver()
+    observer.trigger() // mandatory initial callback — ignored by the guard
+    observer.trigger() // real scroll-triggered intersection
 
     await waitFor(() => {
       expect(screen.getAllByRole('img')).toHaveLength(13)
@@ -108,7 +111,8 @@ describe('GalleryGrid infinite scroll', () => {
 
     render(<GalleryGrid initialImages={initialImages} initialHasMore={true} />)
     const observer = latestObserver()
-    observer.trigger()
+    observer.trigger() // mandatory initial callback — ignored by the guard
+    observer.trigger() // first real intersection — triggers the fetch
 
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
 
@@ -132,11 +136,35 @@ describe('GalleryGrid infinite scroll', () => {
 
     observer.trigger()
     observer.trigger()
+    observer.trigger()
 
     expect(fetch).toHaveBeenCalledTimes(1)
 
     resolveFetch(mockPayloadResponse([], true) as Response)
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not fetch on initial render even if the sentinel is already intersecting', async () => {
+    render(<GalleryGrid initialImages={initialImages} initialHasMore={true} />)
+    latestObserver().trigger(true)
+    await new Promise((r) => setTimeout(r, 0))
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches on the first real intersection after the initial mount callback', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockPayloadResponse(
+        [{ src: '/image-12.jpg', alt: 'Image 12' }],
+        true,
+      ) as Response,
+    )
+    render(<GalleryGrid initialImages={initialImages} initialHasMore={true} />)
+    const observer = latestObserver()
+    observer.trigger(true)
+    observer.trigger(true)
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
   })
 })
 

--- a/src/app/(frontend)/gallery/_components/gallery-images/GalleryGrid.tsx
+++ b/src/app/(frontend)/gallery/_components/gallery-images/GalleryGrid.tsx
@@ -31,6 +31,7 @@ export function GalleryGrid({
   const hasMoreRef = useRef(initialHasMore)
   const pageRef = useRef(1)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const isInitialCallbackRef = useRef(true)
 
   const availableTags = useMemo(() => {
     const tagSet = new Set<string>()
@@ -86,13 +87,16 @@ export function GalleryGrid({
   useEffect(() => {
     const sentinel = sentinelRef.current
     if (!sentinel) return
-
+    isInitialCallbackRef.current = true
     const observer = new IntersectionObserver((entries) => {
+      if (isInitialCallbackRef.current) {
+        isInitialCallbackRef.current = false
+        return
+      }
       if (entries[0].isIntersecting) {
         fetchNextPage()
       }
     })
-
     observer.observe(sentinel)
     return () => observer.disconnect()
   }, [fetchNextPage])


### PR DESCRIPTION
closes #<issue_number>

## 🌟 Context <!-- What is the purpose of this PR? -->

<!--
Link to related issues, user stories, or tasks: #<issue_number>
Mention relevant sprints or milestones.
Describe the main goal of this change and why it's needed
Include any business context or requirements driving this change
-->
Added an isInitialCallbackRef ref that tracks whether the observer's callback has fired yet for the current observer instance. The first callback invocation is now skipped entirely (no fetch, no state change. Only subsequent callbacks can trigger fetchNextPage(). The ref resets at the top of the useEffect so this applies correctly each time the observer is re-created (e.g. after fetchNextPage's dependencies change).

---

## 📝 Description <!--What changes have been made? -->

<!--
Briefly describe key updates — new features, bug fixes, or refactors.
Highlight any important design or architectural decisions.
Explain how these changes address the issue/requirement
Include any dependencies that are required for this change
-->

---

## 📋 Notes <!--Are there any important details for reviewers? -->

<!--
Potential risks or breaking changes.
Edge cases or areas requiring special attention.
Anything you want feedback on!
List any manual testing you've performed
Mention any documentation that needs updating as a result
-->
The overall infinite scroll approach is unchanged.